### PR TITLE
FEATURE: Hide webp files in file list

### DIFF
--- a/Classes/Fal/Filter/GeneratedFileNamesFilter.php
+++ b/Classes/Fal/Filter/GeneratedFileNamesFilter.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Netlogix\Nximageoptimizer\Fal\Filter;
+
+use TYPO3\CMS\Core\Resource\Driver\DriverInterface;
+use TYPO3\CMS\Core\Resource\Driver\LocalDriver;
+
+class GeneratedFileNamesFilter
+{
+    public static function filterGeneratedFiles(
+        $itemName,
+        $itemIdentifier,
+        $parentIdentifier,
+        array $additionalInformation,
+        DriverInterface $driverInstance
+    ) {
+        if (!$driverInstance instanceof LocalDriver) {
+            return true;
+        }
+        if (preg_match('%.+\.(jpe?g|png)\.webp$%i', $itemName)) {
+            return -1;
+        }
+        return true;
+    }
+}

--- a/Classes/Service/ImageService.php
+++ b/Classes/Service/ImageService.php
@@ -11,7 +11,7 @@ class ImageService extends \TYPO3\CMS\Extbase\Service\ImageService
     /**
      * @inheritdoc
      */
-    public function applyProcessingInstructions($image, array $processingInstructions): ProcessedFile
+    public function applyProcessingInstructions($image, $processingInstructions): ProcessedFile
     {
         $quality = MathUtility::forceIntegerInRange($GLOBALS['TYPO3_CONF_VARS']['GFX']['jpg_quality'], 10, 100, 75);
         if ($image->getMimeType() === 'image/png') {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "typo3-cms-extension",
   "description": "Optimize images when they are processed by the resource publisher",
   "require": {
-    "typo3/cms-core": "^10.4"
+    "typo3/cms-core": "~8.7.0 || ~9.5.0 || ^10.4"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -21,11 +21,11 @@ $EM_CONF['nximageoptimizer'] = [
     'author_company' => '',
     'CGLcompliance' => '',
     'CGLcompliance_note' => '',
-    'version' => '3.0.0',
+    'version' => '3.1.0',
     '_md5_values_when_last_written' => '',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.0-10.99.99',
+            'typo3' => '8.7.0-9.5.99,10.4.0-10.99.99',
         ],
         'conflicts' => [],
         'suggests' => []

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -29,4 +29,9 @@ defined('TYPO3_MODE') or die();
         ],
     ];
 
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['defaultFilterCallbacks'][\Netlogix\Nximageoptimizer\Fal\Filter\GeneratedFileNamesFilter::class] = [
+        \Netlogix\Nximageoptimizer\Fal\Filter\GeneratedFileNamesFilter::class,
+        'filterGeneratedFiles'
+    ];
+
 })();


### PR DESCRIPTION
When browsers request jpg or png files and a corresponding webp file
is available the webp file is returned instead. Webp files are created
automatically.

This patch now hides the automatically created webp files in the TYPO3
because having those in place is an implementation detail when it comes
to editors selecting files.