### PR TITLE
CLEANUP: ignore ext scanner errors

### DIFF
--- a/Classes/EventListener/ImageOptimizer.php
+++ b/Classes/EventListener/ImageOptimizer.php
@@ -107,6 +107,7 @@ class ImageOptimizer implements SingletonInterface
     {
         $lastOutputLine = CommandUtility::exec($command, $output, $returnValue);
         if ($returnValue !== 0) {
+            // @extensionScannerIgnoreLine
             $this->logger->error($lastOutputLine, ['command' => $command]);
         }
     }

--- a/Tests/Unit/Service/ImageServiceTest.php
+++ b/Tests/Unit/Service/ImageServiceTest.php
@@ -23,6 +23,8 @@ class ImageServiceTest extends UnitTestCase
         switch ((new Typo3Version())->getMajorVersion()) {
             case 10:
                 $this->subject = new ImageService(
+                // this is an acceptable false positive due to backwards compatibility
+                // @extensionScannerIgnoreLine
                     $this->createMock(EnvironmentService::class),
                     $this->createMock(ResourceFactory::class)
                 );


### PR DESCRIPTION
These errors are either false positives or are caused by the backwards compatibility with TYPO3 10.