### PR TITLE
BUGFIX: disable image optimization in BE context

### DIFF
--- a/Classes/EventListener/ImageOptimizer.php
+++ b/Classes/EventListener/ImageOptimizer.php
@@ -24,6 +24,13 @@ class ImageOptimizer implements SingletonInterface
 
     public function optimizeImage(AfterFileProcessingEvent $event)
     {
+        // this is needed for backwards compatibility
+        // @extensionScannerIgnoreLine
+        if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_FE)) {
+            // this is not needed for TYPO3 backend and would break deferred image processing
+            return;
+        }
+
         // Backend introduced a DeferredBackendImageProcessor and creates thumbnails async.
         // Currently there is no api to check if the image is processed asynchronously, therefore we disable processing for backend preview images.
         // https://forge.typo3.org/issues/92188


### PR DESCRIPTION
TYPO3 backend introduced deferred thumbnail creation in TYPO3 10.x. After TYPO3 11.x, this is not compatible with the approach this extension uses.

Since this extension aims at optimizing images for frontend rendering, this functionality is disabled when not running in FE context.