### PR TITLE
FEATURE: use FAL API for image manipulation

### DIFF
--- a/Classes/EventListener/AbstractImageOptimizer.php
+++ b/Classes/EventListener/AbstractImageOptimizer.php
@@ -33,6 +33,10 @@ abstract class AbstractImageOptimizer implements SingletonInterface, LoggerAware
 			return false;
 		}
 
+		if (get_class($this) == WebpCreator::class && $this->configuration['disableAutomaticWebpCreation']) {
+			return false;
+		}
+
 		// Backend introduced a DeferredBackendImageProcessor and creates thumbnails async.
 		// Currently, there is no api to check if the image is processed asynchronously, therefore we disable processing for backend preview images.
 		// https://forge.typo3.org/issues/92188

--- a/Classes/EventListener/AbstractImageOptimizer.php
+++ b/Classes/EventListener/AbstractImageOptimizer.php
@@ -33,10 +33,6 @@ abstract class AbstractImageOptimizer implements SingletonInterface, LoggerAware
 			return false;
 		}
 
-		if (get_class($this) == WebpCreator::class && $this->configuration['disableAutomaticWebpCreation']) {
-			return false;
-		}
-
 		// Backend introduced a DeferredBackendImageProcessor and creates thumbnails async.
 		// Currently, there is no api to check if the image is processed asynchronously, therefore we disable processing for backend preview images.
 		// https://forge.typo3.org/issues/92188

--- a/Classes/EventListener/AbstractImageOptimizer.php
+++ b/Classes/EventListener/AbstractImageOptimizer.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\Nximageoptimizer\EventListener;
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Resource\AbstractFile;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\CommandUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+abstract class AbstractImageOptimizer implements SingletonInterface, LoggerAwareInterface
+{
+	use LoggerAwareTrait;
+
+	protected array $configuration;
+
+	public function __construct()
+	{
+		$this->configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('nximageoptimizer');
+	}
+
+	protected function isEnabled(ProcessedFile $processedFile): bool
+	{
+		// this is needed for backwards compatibility
+		// @extensionScannerIgnoreLine
+		if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_FE)) {
+			// this is not needed for TYPO3 backend and would break deferred image processing
+			return false;
+		}
+
+		// Backend introduced a DeferredBackendImageProcessor and creates thumbnails async.
+		// Currently, there is no api to check if the image is processed asynchronously, therefore we disable processing for backend preview images.
+		// https://forge.typo3.org/issues/92188
+		// https://forge.typo3.org/issues/93245
+		if ($processedFile->getTaskIdentifier() === ProcessedFile::CONTEXT_IMAGEPREVIEW) {
+			return false;
+		}
+
+		// if the processed file did not change then there is nothing to do here
+		if (!$processedFile->isUpdated()) {
+			return false;
+		}
+
+		// only optimize images here
+		if ($processedFile->getType() !== AbstractFile::FILETYPE_IMAGE) {
+			return false;
+		}
+
+		return true;
+	}
+
+	protected function exec(string $command): void
+	{
+		$lastOutputLine = CommandUtility::exec($command, $output, $returnValue);
+		if ($returnValue !== 0) {
+			// @extensionScannerIgnoreLine
+			$this->logger->error($lastOutputLine, ['command' => $command]);
+		}
+	}
+}

--- a/Classes/EventListener/ImageOptimizer.php
+++ b/Classes/EventListener/ImageOptimizer.php
@@ -1,131 +1,76 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Netlogix\Nximageoptimizer\EventListener;
 
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Core\Log\Logger;
-use TYPO3\CMS\Core\Log\LogManager;
-use TYPO3\CMS\Core\Resource\AbstractFile;
 use TYPO3\CMS\Core\Resource\Event\AfterFileProcessingEvent;
 use TYPO3\CMS\Core\Resource\ProcessedFile;
-use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\CommandUtility;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class ImageOptimizer implements SingletonInterface
+class ImageOptimizer extends AbstractImageOptimizer
 {
 
-    protected Logger $logger;
+	public function optimizeImage(AfterFileProcessingEvent $event)
+	{
+		if (!$this->isEnabled($event->getProcessedFile())) {
+			return;
+		}
 
-    protected array $configuration;
+		$this->processImage($event->getProcessedFile());
+	}
 
-    public function __construct()
-    {
-        $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(self::class);
-        $this->configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('nximageoptimizer');
-    }
+	/**
+	 * Replaces the processed file with an optimized one.
+	 *
+	 * @param ProcessedFile $processedFile
+	 * @return void
+	 */
+	private function processImage(ProcessedFile $processedFile): void
+	{
+		$localProcessingPath = $processedFile->getForLocalProcessing(true);
 
-    public function optimizeImage(AfterFileProcessingEvent $event)
-    {
-        // this is needed for backwards compatibility
-        // @extensionScannerIgnoreLine
-        if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_FE)) {
-            // this is not needed for TYPO3 backend and would break deferred image processing
-            return;
-        }
+		$path = CommandUtility::escapeShellArgument(realpath($localProcessingPath));
+		switch ($processedFile->getMimeType()) {
+			case 'image/jpeg':
+				if (CommandUtility::checkCommand('jpegoptim')) {
+					$command = CommandUtility::getCommand('jpegoptim');
+					$parameters = sprintf('-m85 --strip-all --all-progressive %s', $path);
+					$this->exec($command . ' ' . $parameters . ' 2>&1');
+				}
+				break;
+			case 'image/png':
+				if (CommandUtility::checkCommand('pngquant')) {
+					$command = CommandUtility::getCommand('pngquant');
+					$parameters = sprintf('--force %s --output=%s', $path, $path);
+					$this->exec($command . ' ' . $parameters . ' 2>&1');
+				}
+				if (CommandUtility::checkCommand('optipng')) {
+					$command = CommandUtility::getCommand('optipng');
+					$parameters = sprintf('-i0 -o2 -quiet %s', $path);
+					$this->exec($command . ' ' . $parameters . ' 2>&1');
+				}
+				break;
+			case 'image/gif':
+				if (CommandUtility::checkCommand('gifsicle')) {
+					$command = CommandUtility::getCommand('gifsicle');
+					$parameters = sprintf('-b -O3 %s', $path);
+					$this->exec($command . ' ' . $parameters . ' 2>&1');
+				}
+				break;
+			case 'image/svg+xml':
+				if (CommandUtility::checkCommand('svgo')) {
+					$command = CommandUtility::getCommand('svgo');
+					$parameters = sprintf('--disable=cleanupIDs %s', $path);
+					$this->exec($command . ' ' . $parameters . ' 2>&1');
+				}
+				break;
+			default:
+				break;
+		}
 
-        // Backend introduced a DeferredBackendImageProcessor and creates thumbnails async.
-        // Currently there is no api to check if the image is processed asynchronously, therefore we disable processing for backend preview images.
-        // https://forge.typo3.org/issues/92188
-        // https://forge.typo3.org/issues/93245
-        $processedFile = $event->getProcessedFile();
-        if ($processedFile->getTaskIdentifier() === ProcessedFile::CONTEXT_IMAGEPREVIEW) {
-            return;
-        }
-
-        if ($processedFile->getType() === AbstractFile::FILETYPE_IMAGE && $processedFile->isUpdated()) {
-            $this->createWebpImage($processedFile);
-            $this->processImage($processedFile);
-        }
-    }
-
-    private function processImage(ProcessedFile $processedFile): void
-    {
-        $path = CommandUtility::escapeShellArgument(realpath($processedFile->getForLocalProcessing(false)));
-        switch ($processedFile->getMimeType()) {
-            case 'image/jpeg':
-                if (CommandUtility::checkCommand('jpegoptim')) {
-                    $command = CommandUtility::getCommand('jpegoptim');
-                    $parameters = sprintf('-m85 --strip-all --all-progressive %s', $path);
-                    $this->exec($command . ' ' . $parameters . ' 2>&1');
-                }
-                break;
-            case 'image/png':
-                if (CommandUtility::checkCommand('pngquant')) {
-                    $command = CommandUtility::getCommand('pngquant');
-                    $parameters = sprintf('--force %s --output=%s', $path, $path);
-                    $this->exec($command . ' ' . $parameters . ' 2>&1');
-                }
-                if (CommandUtility::checkCommand('optipng')) {
-                    $command = CommandUtility::getCommand('optipng');
-                    $parameters = sprintf('-i0 -o2 -quiet %s', $path);
-                    $this->exec($command . ' ' . $parameters . ' 2>&1');
-                }
-                break;
-            case 'image/gif':
-                if (CommandUtility::checkCommand('gifsicle')) {
-                    $command = CommandUtility::getCommand('gifsicle');
-                    $parameters = sprintf('-b -O3 %s', $path);
-                    $this->exec($command . ' ' . $parameters . ' 2>&1');
-                }
-                break;
-            case 'image/svg+xml':
-                if (CommandUtility::checkCommand('svgo')) {
-                    $command = CommandUtility::getCommand('svgo');
-                    $parameters = sprintf('--disable=cleanupIDs %s', $path);
-                    $this->exec($command . ' ' . $parameters . ' 2>&1');
-                }
-                break;
-            default:
-                return;
-        }
-    }
-
-    private function createWebpImage(ProcessedFile $processedFile): void
-    {
-        if ($this->configuration['disableAutomaticWebpCreation']) {
-            return;
-        }
-
-        $path = realpath($processedFile->getForLocalProcessing(false));
-        switch ($processedFile->getMimeType()) {
-            case 'image/jpeg':
-            case 'image/png':
-                if (CommandUtility::checkCommand('cwebp')) {
-                    $output = $path . '.webp';
-                    $command = CommandUtility::getCommand('cwebp');
-                    $parameters = sprintf(
-                        '-q 85 %s -o %s',
-                        CommandUtility::escapeShellArgument($path),
-                        CommandUtility::escapeShellArgument($output)
-                    );
-                    $this->exec($command . ' ' . $parameters . ' 2>&1');
-                }
-                break;
-            default:
-                return;
-        }
-    }
-
-    private function exec(string $command): void
-    {
-        $lastOutputLine = CommandUtility::exec($command, $output, $returnValue);
-        if ($returnValue !== 0) {
-            // @extensionScannerIgnoreLine
-            $this->logger->error($lastOutputLine, ['command' => $command]);
-        }
-    }
+		$processedFile->updateWithLocalFile($localProcessingPath);
+	}
 
 }
 

--- a/Classes/EventListener/WebpCreator.php
+++ b/Classes/EventListener/WebpCreator.php
@@ -61,11 +61,11 @@ class WebpCreator extends AbstractImageOptimizer
 		}
 
 		if ($targetFolder->hasFile($targetFileName)) {
-			$fileIdentifier = $driver->getFileInFolder(
+			$webpFileIdentifier = $driver->getFileInFolder(
 				$targetFileName,
 				$targetFolder->getIdentifier()
 			);
-			$driver->replaceFile($fileIdentifier, $localProcessingPath);
+			$driver->replaceFile($webpFileIdentifier, $targetPath);
 		} else {
 			$driver->addFile($localProcessingPath, $targetFolder->getIdentifier(), $targetFileName);
 		}

--- a/Classes/EventListener/WebpCreator.php
+++ b/Classes/EventListener/WebpCreator.php
@@ -34,19 +34,18 @@ class WebpCreator extends AbstractImageOptimizer
 	 */
 	private function createWebpImage(ProcessedFile $processedFile, DriverInterface $driver): void
 	{
-
-		$targetFileName = $processedFile->getName() . '.webp';
+		$webpFileName = $processedFile->getName() . '.webp';
 		$targetFolder = $processedFile->getParentFolder();
 
-		$localProcessingPath = $processedFile->getForLocalProcessing();
+		$originalProcessingPath = $processedFile->getForLocalProcessing();
 
-		$path = realpath($localProcessingPath);
-		$targetPath = $path . '.webp';
+		$path = realpath($originalProcessingPath);
+		$webpTempPath = $path . '.webp';
 		switch ($processedFile->getMimeType()) {
 			case 'image/jpeg':
 			case 'image/png':
 				if (CommandUtility::checkCommand('cwebp')) {
-					$output = $targetPath;
+					$output = $webpTempPath;
 					$command = CommandUtility::getCommand('cwebp');
 					$parameters = sprintf(
 						'-q 85 %s -o %s',
@@ -60,14 +59,14 @@ class WebpCreator extends AbstractImageOptimizer
 				return;
 		}
 
-		if ($targetFolder->hasFile($targetFileName)) {
+		if ($targetFolder->hasFile($webpFileName)) {
 			$webpFileIdentifier = $driver->getFileInFolder(
-				$targetFileName,
+				$webpFileName,
 				$targetFolder->getIdentifier()
 			);
-			$driver->replaceFile($webpFileIdentifier, $targetPath);
+			$driver->replaceFile($webpFileIdentifier, $webpTempPath);
 		} else {
-			$driver->addFile($targetPath, $targetFolder->getIdentifier(), $targetFileName);
+			$driver->addFile($webpTempPath, $targetFolder->getIdentifier(), $webpFileName);
 		}
 	}
 

--- a/Classes/EventListener/WebpCreator.php
+++ b/Classes/EventListener/WebpCreator.php
@@ -8,6 +8,7 @@ use TYPO3\CMS\Core\Resource\Driver\DriverInterface;
 use TYPO3\CMS\Core\Resource\Event\AfterFileProcessingEvent;
 use TYPO3\CMS\Core\Resource\ProcessedFile;
 use TYPO3\CMS\Core\Utility\CommandUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class WebpCreator extends AbstractImageOptimizer
 {
@@ -61,6 +62,9 @@ class WebpCreator extends AbstractImageOptimizer
 			CommandUtility::escapeShellArgument($output)
 		);
 		$this->exec($command . ' ' . $parameters . ' 2>&1');
+
+		// the source temp file is not needed anymore
+		GeneralUtility::unlink_tempfile($originalProcessingPath);
 
 		if ($targetFolder->hasFile($webpFileName)) {
 			$webpFileIdentifier = $driver->getFileInFolder(

--- a/Classes/EventListener/WebpCreator.php
+++ b/Classes/EventListener/WebpCreator.php
@@ -30,10 +30,6 @@ class WebpCreator extends AbstractImageOptimizer
 	 */
 	private function createWebpImage(ProcessedFile $processedFile, DriverInterface $driver): void
 	{
-		if ($this->configuration['disableAutomaticWebpCreation']) {
-			return;
-		}
-
 		$targetFileName = $processedFile->getName() . '.webp';
 		$targetFolder = $processedFile->getParentFolder();
 

--- a/Classes/EventListener/WebpCreator.php
+++ b/Classes/EventListener/WebpCreator.php
@@ -14,6 +14,10 @@ class WebpCreator extends AbstractImageOptimizer
 
 	public function createWebpVersion(AfterFileProcessingEvent $event)
 	{
+        if ($this->configuration['disableAutomaticWebpCreation']) {
+            return;
+        }
+
 		if (!$this->isEnabled($event->getProcessedFile())) {
 			return;
 		}
@@ -30,9 +34,6 @@ class WebpCreator extends AbstractImageOptimizer
 	 */
 	private function createWebpImage(ProcessedFile $processedFile, DriverInterface $driver): void
 	{
-		if ($this->configuration['disableAutomaticWebpCreation']) {
-			return;
-		}
 
 		$targetFileName = $processedFile->getName() . '.webp';
 		$targetFolder = $processedFile->getParentFolder();

--- a/Classes/EventListener/WebpCreator.php
+++ b/Classes/EventListener/WebpCreator.php
@@ -67,7 +67,7 @@ class WebpCreator extends AbstractImageOptimizer
 			);
 			$driver->replaceFile($webpFileIdentifier, $targetPath);
 		} else {
-			$driver->addFile($localProcessingPath, $targetFolder->getIdentifier(), $targetFileName);
+			$driver->addFile($targetPath, $targetFolder->getIdentifier(), $targetFileName);
 		}
 	}
 

--- a/Classes/EventListener/WebpCreator.php
+++ b/Classes/EventListener/WebpCreator.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\Nximageoptimizer\EventListener;
+
+use TYPO3\CMS\Core\Resource\Driver\DriverInterface;
+use TYPO3\CMS\Core\Resource\Event\AfterFileProcessingEvent;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Utility\CommandUtility;
+
+class WebpCreator extends AbstractImageOptimizer
+{
+
+	public function createWebpVersion(AfterFileProcessingEvent $event)
+	{
+		if (!$this->isEnabled($event->getProcessedFile())) {
+			return;
+		}
+
+		$this->createWebpImage($event->getProcessedFile(), $event->getDriver());
+	}
+
+	/**
+	 * Creates a .webp version of the processed image file.
+	 *
+	 * @param ProcessedFile $processedFile
+	 * @param DriverInterface $driver
+	 * @return void
+	 */
+	private function createWebpImage(ProcessedFile $processedFile, DriverInterface $driver): void
+	{
+		if ($this->configuration['disableAutomaticWebpCreation']) {
+			return;
+		}
+
+		$targetFileName = $processedFile->getName() . '.webp';
+		$targetFolder = $processedFile->getParentFolder();
+
+		$localProcessingPath = $processedFile->getForLocalProcessing();
+
+		$path = realpath($localProcessingPath);
+		$targetPath = $path . '.webp';
+		switch ($processedFile->getMimeType()) {
+			case 'image/jpeg':
+			case 'image/png':
+				if (CommandUtility::checkCommand('cwebp')) {
+					$output = $targetPath;
+					$command = CommandUtility::getCommand('cwebp');
+					$parameters = sprintf(
+						'-q 85 %s -o %s',
+						CommandUtility::escapeShellArgument($path),
+						CommandUtility::escapeShellArgument($output)
+					);
+					$this->exec($command . ' ' . $parameters . ' 2>&1');
+				}
+				break;
+			default:
+				return;
+		}
+
+		if ($targetFolder->hasFile($targetFileName)) {
+			$fileIdentifier = $driver->getFileInFolder(
+				$targetFileName,
+				$targetFolder->getIdentifier()
+			);
+			$driver->replaceFile($fileIdentifier, $localProcessingPath);
+		} else {
+			$driver->addFile($localProcessingPath, $targetFolder->getIdentifier(), $targetFileName);
+		}
+	}
+
+}
+

--- a/Classes/EventListener/WebpCreator.php
+++ b/Classes/EventListener/WebpCreator.php
@@ -30,6 +30,10 @@ class WebpCreator extends AbstractImageOptimizer
 	 */
 	private function createWebpImage(ProcessedFile $processedFile, DriverInterface $driver): void
 	{
+		if ($this->configuration['disableAutomaticWebpCreation']) {
+			return;
+		}
+
 		$targetFileName = $processedFile->getName() . '.webp';
 		$targetFolder = $processedFile->getParentFolder();
 

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -12,3 +12,10 @@ services:
         identifier: 'optimizeImage'
         method: 'optimizeImage'
         event: TYPO3\CMS\Core\Resource\Event\AfterFileProcessingEvent
+
+  Netlogix\Nximageoptimizer\EventListener\WebpCreator:
+    tags:
+      - name: event.listener
+        identifier: 'createWebpVersion'
+        method: 'createWebpVersion'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFileProcessingEvent


### PR DESCRIPTION
This fixes several problems:
* possible temp files were not cleaned up
* file metadata in FAL was wrong after images were optimized

Additionally, this introduces support for non-local file storages as a side effect.

Another cleanup splits the ImageOptimizer into two distinct EventListeners.